### PR TITLE
rbx-2.0 and rbx are both just aliases for Rubinius in 1.8 mode (rbx-18mode)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 1.9.2
   - 1.9.3
   - jruby
-  - rbx-2.0
   - rbx-18mode
   - ree
   - ruby-head


### PR DESCRIPTION
So no need to double-test
