### PR TITLE
#16 Including rack dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "http://rubygems.org"
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
+gem 'rack'


### PR DESCRIPTION
Gravatar.new("generic@example.com").image_url fails without rack being installed.
