### PR TITLE
Add xmlrpc to dependency

### DIFF
--- a/gravatar-ultimate.gemspec
+++ b/gravatar-ultimate.gemspec
@@ -29,6 +29,7 @@ rather than just a URL to that data. This saves you the extra step of having to 
   
   s.add_dependency('activesupport', '>= 2.3.14')
   s.add_dependency('rack')
+  s.add_dependency('xmlrpc')
 
   s.add_development_dependency('rspec', ">= 1.3.0")
   s.add_development_dependency('fakeweb', ">= 1.2.8")


### PR DESCRIPTION
xmlrpc library has been extracted as bundled gem from Ruby 2.4.
see: https://bugs.ruby-lang.org/issues/12160

So, need to add xmlrpc gem to dependencies, for Ruby 2.4 or later.

```
LoadError: cannot load such file -- xmlrpc/client
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:292:in `require'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:292:in `block in require'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:258:in `load_dependency'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:292:in `require'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gravatar-ultimate-2.0.0/lib/gravatar/dependencies.rb:5:in `<top (required)>'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:292:in `require'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:292:in `block in require'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:258:in `load_dependency'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/dependencies.rb:292:in `require'
  /Users/michiomochi/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gravatar-ultimate-2.0.0/lib/gravatar.rb:3:in `<top (required)>'
```