### PR TITLE
Change domain to www.gravatar.com, which is now the only working domain

### DIFF
--- a/lib/gravatar.rb
+++ b/lib/gravatar.rb
@@ -8,7 +8,6 @@ require File.expand_path("../gravatar/cache", __FILE__)
 # Errors usually come with a number and human readable text. Generally the text should be followed whenever possible,
 # but a brief description of the numeric error codes are as follows:
 #
-#     -7  Use secure.gravatar.com
 #     -8  Internal error
 #     -9  Authentication error
 #     -10 Method parameter missing
@@ -49,7 +48,7 @@ class Gravatar
   end
   
   def host
-    "secure.gravatar.com"
+    "www.gravatar.com"
   end
   
   def url

--- a/spec/lib/gravatar_spec.rb
+++ b/spec/lib/gravatar_spec.rb
@@ -133,7 +133,7 @@ describe Gravatar do
     end
 
     it "should return gravatar image_url with SSL" do
-      image_url(:ssl => true).should == "https://secure.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98"
+      image_url(:ssl => true).should == "https://www.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98"
     end
 
     it "should return gravatar image_url with size" do
@@ -166,10 +166,10 @@ describe Gravatar do
 
     it "should return gravatar image_url with SSL and default and size and rating" do
       combinations = %w(
-        https://secure.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?default=identicon&size=80&rating=g
-        https://secure.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?size=80&rating=g&default=identicon
-        https://secure.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?size=80&default=identicon&rating=g
-        https://secure.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?rating=g&size=80&default=identicon
+        https://www.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?default=identicon&size=80&rating=g
+        https://www.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?size=80&rating=g&default=identicon
+        https://www.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?size=80&default=identicon&rating=g
+        https://www.gravatar.com/avatar/ef23bdc1f1fb9e3f46843a00e5832d98?rating=g&size=80&default=identicon
       )
       combinations.should include(image_url(:ssl => true, :default => "identicon", :size => 80, :rating => :g))
     end


### PR DESCRIPTION
Looks like gravatar has long supported https on 'www', and recently they've turned off the 'secure' domain so this PR moves us wholesale to that domain.